### PR TITLE
feat: add filters and conditionally restore/clear

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,5 +1,4 @@
 <app-nav-bar></app-nav-bar>
-<app-side-bar></app-side-bar>
 <div class="container">
-<router-outlet></router-outlet>
+    <router-outlet></router-outlet>
 </div>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -3,7 +3,6 @@ import { Component, OnInit } from '@angular/core';
 import { environment } from '../environments/environment.development';
 import { NavBarComponent } from "./nav-bar/nav-bar.component";
 import { RouterOutlet } from '@angular/router';
-import { SideBarComponent } from './side-bar/side-bar.component';
 
 @Component({
     selector: 'app-root',
@@ -11,7 +10,6 @@ import { SideBarComponent } from './side-bar/side-bar.component';
     styleUrl: './app.component.scss',
     imports: [
       NavBarComponent,
-      SideBarComponent,
       RouterOutlet
     ]
 })

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -5,7 +5,7 @@ import { OffersComponent } from './offers/offers.component';
 
 export const routes: Routes = [
     { path: "navbar", component: NavBarComponent },
-    { path: "offers", component: OffersComponent },
-    { path: "offers/:id", component: OfferItemComponent},
+    { path: "offers/:category", component: OffersComponent },
+    { path: "offers/:category/:id", component: OfferItemComponent},
     { path: "", redirectTo: "offers", pathMatch: "full" }
 ];

--- a/src/app/nav-bar/nav-bar.component.html
+++ b/src/app/nav-bar/nav-bar.component.html
@@ -4,8 +4,8 @@
           <mat-icon>home</mat-icon>
         </button>
   
-        <a mat-flat-button color="primary" [routerLink]="['/offers']" [queryParams]="{ category: 'Desktops' }">Desktops</a>
-        <a mat-flat-button color="primary" [routerLink]="['/offers']" [queryParams]="{ category: 'Laptops' }">Laptops</a>
+        <a mat-flat-button color="primary" [routerLink]="['/offers', 'Desktops']">Desktops</a>
+        <a mat-flat-button color="primary" [routerLink]="['/offers', 'Laptops']">Laptops</a>
         <span class="separator"></span>
     </mat-toolbar>
   </header>

--- a/src/app/offer-item/offer-item.component.ts
+++ b/src/app/offer-item/offer-item.component.ts
@@ -1,5 +1,5 @@
 import { Component } from '@angular/core';
-import { ActivatedRoute, RouterLink } from '@angular/router';
+import { ActivatedRoute } from '@angular/router';
 import { Offer } from '../offer';
 import { HttpClient } from '@angular/common/http';
 import { environment } from '../../environments/environment.development';
@@ -7,9 +7,7 @@ import { Location } from '@angular/common';
 
 @Component({
   selector: 'app-offer-item',
-  imports: [
-    RouterLink
-  ],
+  imports: [],
   templateUrl: './offer-item.component.html',
   styleUrl: './offer-item.component.scss'
 })

--- a/src/app/offer.ts
+++ b/src/app/offer.ts
@@ -1,5 +1,6 @@
 export interface Offer {
     id: number;
+    category: string;
     title: string;
     photo: string;
     price: string; // type: no calculations are performed

--- a/src/app/offers/offers.component.html
+++ b/src/app/offers/offers.component.html
@@ -1,7 +1,7 @@
 <mat-drawer-container> <!-- Component controls drawer open/close. -->
   <!-- Non-navigation, hence drawer rather than side-nav. -->
   <mat-drawer mode="side" opened>
-    <app-side-bar></app-side-bar>
+    <app-side-bar (selectedMemoryChanged)="onMemoryChange($event)"></app-side-bar>
   </mat-drawer>
   <mat-drawer-content>
     <h2>Offers</h2>
@@ -14,7 +14,7 @@
             at https://material.angular.io/components/card/examples#card-fancy
           -->
           <mat-card [routerLink]="['/offers', offer.id]">
-            <img mat-card-image src="{{offer.photo}}">
+            <img mat-card-image src="{{ offer.photo }}">
             <mat-card-header>
               <mat-card-title>{{ offer.title }}</mat-card-title>
             </mat-card-header>

--- a/src/app/offers/offers.component.html
+++ b/src/app/offers/offers.component.html
@@ -1,32 +1,39 @@
-<h1>Offers</h1>
-
-@if (pagedOffers) {
-  <mat-grid-list cols="3">
-  @for (offer of pagedOffers; track offer.id) {
-    <mat-grid-tile>
-      <!--
-        Adapted from example in Angular Material documentation
-        at https://material.angular.io/components/card/examples#card-fancy
-      -->
-      <mat-card [routerLink]="['/offers', offer.id]">
-        <img mat-card-image src="{{offer.photo}}">
-        <mat-card-header>
-          <mat-card-title>{{ offer.title }}</mat-card-title>
-        </mat-card-header>
-        <mat-card-content>
+<mat-drawer-container> <!-- Component controls drawer open/close. -->
+  <!-- Non-navigation, hence drawer rather than side-nav. -->
+  <mat-drawer mode="side" opened>
+    <app-side-bar></app-side-bar>
+  </mat-drawer>
+  <mat-drawer-content>
+    <h2>Offers</h2>
+    @if (pagedOffers) {
+      <mat-grid-list cols="3">
+      @for (offer of pagedOffers; track offer.id) {
+        <mat-grid-tile>
           <!--
-            Currency denomination can be safely hard-coded because
-            Woot! does not ship outside of the contiguous 48 United States.
-            See: https://www.woot.com/faq?ref=w_ngf_rp&tab=account-and-ordering
+            Adapted from example in Angular Material documentation
+            at https://material.angular.io/components/card/examples#card-fancy
           -->
-          <p>${{ offer.price }}</p>
-        </mat-card-content>
-      </mat-card>
-    </mat-grid-tile>
-  }
-  </mat-grid-list>
-} @else {
-  <p><em>Loading...</em></p>
-}
-
-<mat-paginator [length]="length" [pageSize]="pageSize" (page)="onPageChange($event)"></mat-paginator>
+          <mat-card [routerLink]="['/offers', offer.id]">
+            <img mat-card-image src="{{offer.photo}}">
+            <mat-card-header>
+              <mat-card-title>{{ offer.title }}</mat-card-title>
+            </mat-card-header>
+            <mat-card-content>
+              <!--
+                Currency denomination can be safely hard-coded because
+                Woot! does not ship outside of the contiguous 48 United States.
+                See: https://www.woot.com/faq?ref=w_ngf_rp&tab=account-and-ordering
+              -->
+              <p>${{ offer.price }}</p>
+            </mat-card-content>
+          </mat-card>
+        </mat-grid-tile>
+      }
+      </mat-grid-list>
+    } @else {
+      <p><em>Loading...</em></p>
+    }
+    <mat-paginator [length]="length" [pageSize]="pageSize" (page)="onPageChange($event)">
+    </mat-paginator>
+  </mat-drawer-content>
+</mat-drawer-container>

--- a/src/app/offers/offers.component.html
+++ b/src/app/offers/offers.component.html
@@ -1,7 +1,7 @@
 <mat-drawer-container> <!-- Component controls drawer open/close. -->
   <!-- Non-navigation, hence drawer rather than side-nav. -->
   <mat-drawer mode="side" opened>
-    <app-side-bar (selectedMemoryChanged)="onMemoryChange($event)"></app-side-bar>
+    <app-side-bar (selectedFiltersChanged)="onFiltersChange($event)"></app-side-bar>
   </mat-drawer>
   <mat-drawer-content>
     <h2>Offers</h2>

--- a/src/app/offers/offers.component.html
+++ b/src/app/offers/offers.component.html
@@ -13,7 +13,7 @@
             Adapted from example in Angular Material documentation
             at https://material.angular.io/components/card/examples#card-fancy
           -->
-          <mat-card [routerLink]="['/offers', offer.id]">
+          <mat-card [routerLink]="['/offers', offer.category, offer.id]">
             <img mat-card-image src="{{ offer.photo }}">
             <mat-card-header>
               <mat-card-title>{{ offer.title }}</mat-card-title>

--- a/src/app/offers/offers.component.ts
+++ b/src/app/offers/offers.component.ts
@@ -31,6 +31,7 @@ export class OffersComponent implements OnInit {
   pageSize: number = 12;
   category: string = '';
   memory: number[] = [];
+  storage: number[] = [];
 
   @ViewChild(MatPaginator) paginator!: MatPaginator;
 
@@ -43,8 +44,10 @@ export class OffersComponent implements OnInit {
     this.activatedRoute.queryParams.subscribe(params => {
       this.category = params['category'] || '';
       this.memory = (params['memory']) || [];
+      this.storage = (params['storage']) || [];
       let page = params['page'] || 0;
-      this.getOffers(params = new HttpParams().set('category', this.category).appendAll({'memory' : this.memory}));
+      this.getOffers(params = new HttpParams().set('category', this.category)
+      .appendAll({'memory' : this.memory, 'storage' : this.storage}));
       this.router.navigate([], {
         relativeTo: this.activatedRoute,
         queryParams: { page: page, memory: this.memory },
@@ -71,20 +74,25 @@ export class OffersComponent implements OnInit {
   }
 
   // Append parameters for memory in the request, then paginate the response.
-  onMemoryChange(filters: {memory: number[]}) {
+  onFiltersChange(filters: {memory: number[]; storage: number[]}) {
     let params = new HttpParams();
     this.memory = filters.memory;
+    this.storage = filters.storage;
   
     this.memory.forEach(selected => params = params.append('memory', selected));
-    // params.appendAll({'memory' : memory});
+    this.storage.forEach(selected => params = params.append('storage', selected));
 
     this.getOffers(params);
-    
     this.pagedOffers = this.offers.slice(0, 12);
     this.length = this.offers.length;
+
     this.router.navigate([], {
       relativeTo: this.activatedRoute,
-      queryParams: { page: 0, memory: params.getAll('memory') },
+      queryParams: { 
+        page: 0,
+        memory: params.getAll('memory'),
+        storage: params.getAll('storage'),
+      },
       queryParamsHandling: 'merge',
     });
   }

--- a/src/app/offers/offers.component.ts
+++ b/src/app/offers/offers.component.ts
@@ -41,8 +41,10 @@ export class OffersComponent implements OnInit {
     private router: Router) {}
 
   ngOnInit() {
+    this.activatedRoute.paramMap.subscribe(params => {
+      this.category = params.get('category') || '';
+    });
     this.activatedRoute.queryParams.subscribe(params => {
-      this.category = params['category'] || '';
       this.memory = (params['memory']) || [];
       this.storage = (params['storage']) || [];
       let page = params['page'] || 0;

--- a/src/app/offers/offers.component.ts
+++ b/src/app/offers/offers.component.ts
@@ -50,7 +50,7 @@ export class OffersComponent implements OnInit {
       .appendAll({'memory' : this.memory, 'storage' : this.storage}));
       this.router.navigate([], {
         relativeTo: this.activatedRoute,
-        queryParams: { page: page, memory: this.memory },
+        queryParams: { page: page, memory: this.memory, storage: this.storage },
         queryParamsHandling: 'merge',
       });
     });
@@ -76,15 +76,9 @@ export class OffersComponent implements OnInit {
   // Append parameters for memory in the request, then paginate the response.
   onFiltersChange(filters: {memory: number[]; storage: number[]}) {
     let params = new HttpParams();
-    this.memory = filters.memory;
-    this.storage = filters.storage;
   
-    this.memory.forEach(selected => params = params.append('memory', selected));
-    this.storage.forEach(selected => params = params.append('storage', selected));
-
-    this.getOffers(params);
-    this.pagedOffers = this.offers.slice(0, 12);
-    this.length = this.offers.length;
+    filters.memory.forEach(selected => params = params.append('memory', selected));
+    filters.storage.forEach(selected => params = params.append('storage', selected));
 
     this.router.navigate([], {
       relativeTo: this.activatedRoute,

--- a/src/app/offers/offers.component.ts
+++ b/src/app/offers/offers.component.ts
@@ -30,6 +30,7 @@ export class OffersComponent implements OnInit {
   length: number = 0;
   pageSize: number = 12;
   category: string = '';
+  memory: number[] = [];
 
   @ViewChild(MatPaginator) paginator!: MatPaginator;
 
@@ -41,7 +42,14 @@ export class OffersComponent implements OnInit {
   ngOnInit() {
     this.activatedRoute.queryParams.subscribe(params => {
       this.category = params['category'] || '';
-      this.getOffers(params = new HttpParams().set('category', this.category));
+      this.memory = (params['memory']) || [];
+      let page = params['page'] || 0;
+      this.getOffers(params = new HttpParams().set('category', this.category).appendAll({'memory' : this.memory}));
+      this.router.navigate([], {
+        relativeTo: this.activatedRoute,
+        queryParams: { page: page, memory: this.memory },
+        queryParamsHandling: 'merge',
+      });
     });
   }
 
@@ -65,18 +73,20 @@ export class OffersComponent implements OnInit {
   // Append parameters for memory in the request, then paginate the response.
   onMemoryChange(memory: number[]) {
     let params = new HttpParams();
+    this.memory = memory;
   
-      memory.forEach(selected => params = params.append('memory', selected));
+    memory.forEach(selected => params = params.append('memory', selected));
+    // params.appendAll({'memory' : memory});
 
-      this.getOffers(params);
-      
-      this.pagedOffers = this.offers.slice(0, 12);
-      this.length = this.offers.length;
-      this.router.navigate([], {
-        relativeTo: this.activatedRoute,
-        queryParams: { page: 0 },
-        queryParamsHandling: 'merge',
-      });
+    this.getOffers(params);
+    
+    this.pagedOffers = this.offers.slice(0, 12);
+    this.length = this.offers.length;
+    this.router.navigate([], {
+      relativeTo: this.activatedRoute,
+      queryParams: { page: 0, memory: params.getAll('memory') },
+      queryParamsHandling: 'merge',
+    });
   }
 
   getOffers(params: HttpParams) {

--- a/src/app/offers/offers.component.ts
+++ b/src/app/offers/offers.component.ts
@@ -7,11 +7,15 @@ import { MatGridListModule } from '@angular/material/grid-list';
 import { MatCardModule } from '@angular/material/card';
 import { MatPaginator, MatPaginatorModule, PageEvent } from '@angular/material/paginator';
 import { CommonModule } from '@angular/common';
+import { MatSidenavModule } from '@angular/material/sidenav';
+import { SideBarComponent } from '../side-bar/side-bar.component';
 
 @Component({
   selector: 'app-offers',
   imports: [
     RouterLink,
+    MatSidenavModule,
+    SideBarComponent,
     MatGridListModule,
     MatCardModule,
     MatPaginatorModule,

--- a/src/app/offers/offers.component.ts
+++ b/src/app/offers/offers.component.ts
@@ -71,11 +71,11 @@ export class OffersComponent implements OnInit {
   }
 
   // Append parameters for memory in the request, then paginate the response.
-  onMemoryChange(memory: number[]) {
+  onMemoryChange(filters: {memory: number[]}) {
     let params = new HttpParams();
-    this.memory = memory;
+    this.memory = filters.memory;
   
-    memory.forEach(selected => params = params.append('memory', selected));
+    this.memory.forEach(selected => params = params.append('memory', selected));
     // params.appendAll({'memory' : memory});
 
     this.getOffers(params);

--- a/src/app/side-bar/side-bar.component.html
+++ b/src/app/side-bar/side-bar.component.html
@@ -1,8 +1,8 @@
 <h2>Filters</h2>
 <!-- https://material.angular.io/components/checkbox/examples#checkbox-reactive-forms -->
-<section [formGroup]="_memory">
+<section [formGroup]="memory">
     <h3>Memory Capacity</h3>
-    <p><mat-checkbox formControlName="has8">8 GB</mat-checkbox></p>
-    <p><mat-checkbox formControlName="has16">16 GB</mat-checkbox></p>
-    <p><mat-checkbox formControlName="has32">32 GB</mat-checkbox></p>
+    <p><mat-checkbox formControlName="8">8 GB</mat-checkbox></p>
+    <p><mat-checkbox formControlName="16">16 GB</mat-checkbox></p>
+    <p><mat-checkbox formControlName="32">32 GB</mat-checkbox></p>
 </section>

--- a/src/app/side-bar/side-bar.component.html
+++ b/src/app/side-bar/side-bar.component.html
@@ -1,14 +1,8 @@
-<!-- Drawer complementary to https://m2.material.io/components/sheets-side -->
-<mat-drawer-container>
-    <mat-drawer class="secondary-color" mode="side" opened>
-        <h3>Filter</h3>
-        <!-- Adapted from https://material.angular.io/components/checkbox/examples#checkbox-reactive-forms -->
-        <section class="memory-section" [formGroup]="_memory">
-            <h4>Memory Capacity</h4>
-            <p><mat-checkbox formControlName="has8">8 GB</mat-checkbox></p>
-            <p><mat-checkbox formControlName="has16">16 GB</mat-checkbox></p>
-            <p><mat-checkbox formControlName="has32">32 GB</mat-checkbox></p>
-        </section>
-    </mat-drawer>
-    <mat-drawer-content><router-outlet [routerOutletData]="_memory.value"></router-outlet></mat-drawer-content>
-</mat-drawer-container>
+<h2>Filters</h2>
+<!-- https://material.angular.io/components/checkbox/examples#checkbox-reactive-forms -->
+<section [formGroup]="_memory">
+    <h3>Memory Capacity</h3>
+    <p><mat-checkbox formControlName="has8">8 GB</mat-checkbox></p>
+    <p><mat-checkbox formControlName="has16">16 GB</mat-checkbox></p>
+    <p><mat-checkbox formControlName="has32">32 GB</mat-checkbox></p>
+</section>

--- a/src/app/side-bar/side-bar.component.html
+++ b/src/app/side-bar/side-bar.component.html
@@ -1,8 +1,10 @@
 <h2>Filters</h2>
 <!-- https://material.angular.io/components/checkbox/examples#checkbox-reactive-forms -->
-<section [formGroup]="memory">
-    <h3>Memory Capacity</h3>
-    <p><mat-checkbox formControlName="8">8 GB</mat-checkbox></p>
-    <p><mat-checkbox formControlName="16">16 GB</mat-checkbox></p>
-    <p><mat-checkbox formControlName="32">32 GB</mat-checkbox></p>
+<section [formGroup]="filterForm">
+    <div formGroupName="memory">
+        <h3>Memory Capacity</h3>
+        <p><mat-checkbox formControlName="8">8 GB</mat-checkbox></p>
+        <p><mat-checkbox formControlName="16">16 GB</mat-checkbox></p>
+        <p><mat-checkbox formControlName="32">32 GB</mat-checkbox></p>
+    </div>
 </section>

--- a/src/app/side-bar/side-bar.component.html
+++ b/src/app/side-bar/side-bar.component.html
@@ -7,4 +7,10 @@
         <p><mat-checkbox formControlName="16">16 GB</mat-checkbox></p>
         <p><mat-checkbox formControlName="32">32 GB</mat-checkbox></p>
     </div>
+    <div formGroupName="storage"> <!-- Scope down to nested group. -->
+        <h3>Storage Size</h3>
+        <p><mat-checkbox formControlName="256">256 GB</mat-checkbox></p>
+        <p><mat-checkbox formControlName="512">512 GB</mat-checkbox></p>
+        <p><mat-checkbox formControlName="1000">1 TB</mat-checkbox></p>
+    </div>
 </section>

--- a/src/app/side-bar/side-bar.component.scss
+++ b/src/app/side-bar/side-bar.component.scss
@@ -1,3 +1,0 @@
-.secondary-color {
-    background-color: white;
-}

--- a/src/app/side-bar/side-bar.component.ts
+++ b/src/app/side-bar/side-bar.component.ts
@@ -18,10 +18,10 @@ import { FormBuilder, FormGroup, FormsModule, ReactiveFormsModule } from '@angul
   // changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class SideBarComponent implements OnInit {
-  @Output() selectedMemoryChanged = new EventEmitter<{memory: number[]}>();
+  @Output() selectedFiltersChanged =
+    new EventEmitter<{memory: number[]; storage: number[]}>();
   private readonly formBuilder = inject(FormBuilder);
-
-  constructor(private activatedRoute: ActivatedRoute) {}
+  private readonly activatedRoute = inject(ActivatedRoute);
 
   // https://material.angular.io/components/checkbox/examples#checkbox-reactive-forms
   readonly filterForm = this.formBuilder.group({
@@ -29,12 +29,20 @@ export class SideBarComponent implements OnInit {
       8: false,
       16: false,
       32: false
+    }),
+    storage: this.formBuilder.group({
+      256: false,
+      512: false,
+      1000: false,
     })
   });
 
   ngOnInit(): void {
-    this.memory.valueChanges.subscribe(() => {
-      this.selectedMemoryChanged.emit({memory: this.selectedMemory});
+    this.filterForm.valueChanges.subscribe(() => {
+      this.selectedFiltersChanged.emit({
+        memory: this.selectedMemory,
+        storage: this.selectedStorage
+      });
     });
     this.activatedRoute.queryParams.subscribe(params => {
       let mem: string[] = (params['memory']) || [];
@@ -48,9 +56,20 @@ export class SideBarComponent implements OnInit {
     return this.filterForm.get('memory') as FormGroup;
   }
 
+  get storage() {
+    return this.filterForm.get('storage') as FormGroup;
+  }
+
   get selectedMemory(): number[] {
     return Object.entries(this.memory.value)
-      .filter(([key, value]) => value) // is true
-      .map(([key]) => Number.parseInt(key));
+      .filter(([option, isChecked]) => isChecked) // is true
+      .map(([checked]) => Number.parseInt(checked));
   }
+
+  get selectedStorage(): number[] {
+    return Object.entries(this.storage.value)
+      .filter(([option, isChecked]) => isChecked)
+      .map(([checked]) => Number.parseInt(checked));
+  }
+
 }

--- a/src/app/side-bar/side-bar.component.ts
+++ b/src/app/side-bar/side-bar.component.ts
@@ -2,7 +2,7 @@ import { ChangeDetectionStrategy, Component, EventEmitter, OnInit, Output, injec
 import { ActivatedRoute } from '@angular/router';
 import { MatSidenavModule } from '@angular/material/sidenav';
 import { MatCheckboxModule } from '@angular/material/checkbox';
-import { FormBuilder, FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { FormBuilder, FormGroup, FormsModule, ReactiveFormsModule } from '@angular/forms';
 
 @Component({
   selector: 'app-side-bar',
@@ -18,29 +18,34 @@ import { FormBuilder, FormsModule, ReactiveFormsModule } from '@angular/forms';
   // changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class SideBarComponent implements OnInit {
-  @Output() selectedMemoryChanged = new EventEmitter<number[]>();
+  @Output() selectedMemoryChanged = new EventEmitter<{memory: number[]}>();
   private readonly formBuilder = inject(FormBuilder);
 
   constructor(private activatedRoute: ActivatedRoute) {}
 
   // https://material.angular.io/components/checkbox/examples#checkbox-reactive-forms
-  readonly memory = this.formBuilder.group({
-    8: false,
-    16: false,
-    32: false
+  readonly filterForm = this.formBuilder.group({
+    memory: this.formBuilder.group({
+      8: false,
+      16: false,
+      32: false
+    })
   });
 
   ngOnInit(): void {
     this.memory.valueChanges.subscribe(() => {
-      this.selectedMemoryChanged.emit(this.selectedMemory);
+      this.selectedMemoryChanged.emit({memory: this.selectedMemory});
     });
     this.activatedRoute.queryParams.subscribe(params => {
       let mem: string[] = (params['memory']) || [];
       // restore selections (e.g., when returning from selected offer page)
-      mem.forEach(selected => this.memory.get(selected)?.setValue(true,
+      mem.forEach(selected => this.filterForm.get(selected)?.setValue(true,
         { emitEvent: false })); // prevents call that reset page to 0
-      this.memory.get
     });
+  }
+
+  get memory() {
+    return this.filterForm.get('memory') as FormGroup;
   }
 
   get selectedMemory(): number[] {

--- a/src/app/side-bar/side-bar.component.ts
+++ b/src/app/side-bar/side-bar.component.ts
@@ -1,4 +1,4 @@
-import { AfterViewInit, ChangeDetectionStrategy, Component, EventEmitter, OnInit, Output, inject } from '@angular/core';
+import { AfterViewInit, ChangeDetectionStrategy, ChangeDetectorRef, Component, EventEmitter, OnInit, Output, inject } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { MatSidenavModule } from '@angular/material/sidenav';
 import { MatCheckboxModule } from '@angular/material/checkbox';
@@ -22,6 +22,7 @@ export class SideBarComponent implements OnInit {
     new EventEmitter<{memory: number[]; storage: number[]}>();
   private readonly formBuilder = inject(FormBuilder);
   private readonly activatedRoute = inject(ActivatedRoute);
+  private readonly changeDetectorRef =  inject(ChangeDetectorRef);
 
   checkedMemory: number[] = [];
   category: string = '';
@@ -81,7 +82,8 @@ export class SideBarComponent implements OnInit {
           { emitEvent: false })); 
       }
     });
-    
+    // Run another detection cycle to avoid ExpressionChangedAfterItHasBeenCheckedError
+    this.changeDetectorRef.detectChanges();
   }
 
   get memory() {

--- a/src/app/side-bar/side-bar.component.ts
+++ b/src/app/side-bar/side-bar.component.ts
@@ -23,17 +23,19 @@ export class SideBarComponent implements OnInit {
   private readonly formBuilder = inject(FormBuilder);
   private readonly activatedRoute = inject(ActivatedRoute);
 
+  // category: string = '';
+
   // https://material.angular.io/components/checkbox/examples#checkbox-reactive-forms
   readonly filterForm = this.formBuilder.group({
     memory: this.formBuilder.group({
-      8: false,
-      16: false,
-      32: false
+      8: this.formBuilder.control(false), // define default, for .reset()
+      16: this.formBuilder.control(false),
+      32: this.formBuilder.control(false)
     }),
     storage: this.formBuilder.group({
-      256: false,
-      512: false,
-      1000: false,
+      256: this.formBuilder.control(false),
+      512: this.formBuilder.control(false),
+      1000: this.formBuilder.control(false)
     })
   });
 
@@ -46,9 +48,19 @@ export class SideBarComponent implements OnInit {
     });
     this.activatedRoute.queryParams.subscribe(params => {
       let mem: string[] = (params['memory']) || [];
+      let stor: string[] = (params['storage']) || [];
       // restore selections (e.g., when returning from selected offer page)
-      mem.forEach(selected => this.filterForm.get(selected)?.setValue(true,
+      mem.forEach(selected => this.memory.get(selected)!.setValue(true,
         { emitEvent: false })); // prevents call that reset page to 0
+      stor.forEach(selected => this.storage.get(selected)!.setValue(true,
+        { emitEvent: false }));
+      /*
+      if (this.category != params['category']) {
+        this.category = params['category'];
+        this.filterForm.reset(undefined, { emitEvent: false });
+        // undefined: defaults set
+      }
+      */
     });
   }
 

--- a/src/app/side-bar/side-bar.component.ts
+++ b/src/app/side-bar/side-bar.component.ts
@@ -1,4 +1,5 @@
 import { ChangeDetectionStrategy, Component, EventEmitter, OnInit, Output, inject } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
 import { MatSidenavModule } from '@angular/material/sidenav';
 import { MatCheckboxModule } from '@angular/material/checkbox';
 import { FormBuilder, FormsModule, ReactiveFormsModule } from '@angular/forms';
@@ -20,6 +21,8 @@ export class SideBarComponent implements OnInit {
   @Output() selectedMemoryChanged = new EventEmitter<number[]>();
   private readonly formBuilder = inject(FormBuilder);
 
+  constructor(private activatedRoute: ActivatedRoute) {}
+
   // https://material.angular.io/components/checkbox/examples#checkbox-reactive-forms
   readonly memory = this.formBuilder.group({
     8: false,
@@ -30,6 +33,13 @@ export class SideBarComponent implements OnInit {
   ngOnInit(): void {
     this.memory.valueChanges.subscribe(() => {
       this.selectedMemoryChanged.emit(this.selectedMemory);
+    });
+    this.activatedRoute.queryParams.subscribe(params => {
+      let mem: string[] = (params['memory']) || [];
+      // restore selections (e.g., when returning from selected offer page)
+      mem.forEach(selected => this.memory.get(selected)?.setValue(true,
+        { emitEvent: false })); // prevents call that reset page to 0
+      this.memory.get
     });
   }
 

--- a/src/app/side-bar/side-bar.component.ts
+++ b/src/app/side-bar/side-bar.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, OnInit, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, EventEmitter, OnInit, Output, inject } from '@angular/core';
 import { MatSidenavModule } from '@angular/material/sidenav';
 import { MatCheckboxModule } from '@angular/material/checkbox';
 import { FormBuilder, FormsModule, ReactiveFormsModule } from '@angular/forms';
@@ -16,12 +16,26 @@ import { FormBuilder, FormsModule, ReactiveFormsModule } from '@angular/forms';
   // FIXME: prevents DesktopsComponent initialization
   // changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class SideBarComponent {
-  private readonly _formBuilder = inject(FormBuilder);
+export class SideBarComponent implements OnInit {
+  @Output() selectedMemoryChanged = new EventEmitter<number[]>();
+  private readonly formBuilder = inject(FormBuilder);
 
-  readonly _memory = this._formBuilder.group({
-    has8: false,
-    has16: false,
-    has32: false
+  // https://material.angular.io/components/checkbox/examples#checkbox-reactive-forms
+  readonly memory = this.formBuilder.group({
+    8: false,
+    16: false,
+    32: false
   });
+
+  ngOnInit(): void {
+    this.memory.valueChanges.subscribe(() => {
+      this.selectedMemoryChanged.emit(this.selectedMemory);
+    });
+  }
+
+  get selectedMemory(): number[] {
+    return Object.entries(this.memory.value)
+      .filter(([key, value]) => value) // is true
+      .map(([key]) => Number.parseInt(key));
+  }
 }

--- a/src/app/side-bar/side-bar.component.ts
+++ b/src/app/side-bar/side-bar.component.ts
@@ -1,8 +1,6 @@
 import { ChangeDetectionStrategy, Component, OnInit, inject } from '@angular/core';
 import { MatSidenavModule } from '@angular/material/sidenav';
-import { RouterOutlet } from '@angular/router';
 import { MatCheckboxModule } from '@angular/material/checkbox';
-import { JsonPipe } from '@angular/common';
 import { FormBuilder, FormsModule, ReactiveFormsModule } from '@angular/forms';
 
 @Component({
@@ -10,10 +8,8 @@ import { FormBuilder, FormsModule, ReactiveFormsModule } from '@angular/forms';
   imports: [
     MatSidenavModule,
     MatCheckboxModule,
-    RouterOutlet,
     FormsModule,
     ReactiveFormsModule,
-    JsonPipe
   ],
   templateUrl: './side-bar.component.html',
   styleUrl: './side-bar.component.scss',


### PR DESCRIPTION
To make the filter side-bar and the offers grid-list conform to common user expectations:
- Add the filter type "Storage Size" as a `FormGroup` with its options, "256 GB," "512 GB," and "1 TB," as `FormControls`.
- Restore filter selection state based on query params, in such cases as when back-navigating from the offer details component or when revisiting a bookmarked URL.
- Clear the filter selection when navigating between categories, e.g., from "Desktops" to "Laptops" in `NavBarComponent`.
- Make `category` a route path parameter to distinguish it from filter query parameters, it being used for navigation.
- Update the offers displayed in the grid-list with each change in filter option selection.  Move `mat-drawer-container` into `OffersComponent` and emit filter selection events from `OffersItemComponent`. Rework the event to consist only of selected options (i.e., those options with marked checkboxes).