### PR TITLE
feat: add authentication

### DIFF
--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -2,11 +2,12 @@ import { ApplicationConfig, provideZoneChangeDetection } from '@angular/core';
 import { provideRouter } from '@angular/router';
 
 import { routes } from './app.routes';
-import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClient, withInterceptors } from '@angular/common/http';
+import { authInterceptor } from './auth/auth.interceptor';
 
 export const appConfig: ApplicationConfig = {
   providers: [provideZoneChangeDetection({ eventCoalescing: true }), 
     provideRouter(routes),
-    provideHttpClient()
+    provideHttpClient(withInterceptors([authInterceptor]))
   ]
 };

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -2,8 +2,10 @@ import { Routes } from '@angular/router';
 import { NavBarComponent } from './nav-bar/nav-bar.component';
 import { OfferItemComponent } from './offer-item/offer-item.component';
 import { OffersComponent } from './offers/offers.component';
+import { LoginComponent } from './auth/login.component';
 
 export const routes: Routes = [
+    { path: "login", component: LoginComponent },
     { path: "navbar", component: NavBarComponent },
     { path: "offers/:category", component: OffersComponent },
     { path: "offers/:category/:id", component: OfferItemComponent},

--- a/src/app/auth/auth.interceptor.spec.ts
+++ b/src/app/auth/auth.interceptor.spec.ts
@@ -1,0 +1,17 @@
+import { TestBed } from '@angular/core/testing';
+import { HttpInterceptorFn } from '@angular/common/http';
+
+import { authInterceptor } from './auth.interceptor';
+
+describe('authInterceptor', () => {
+  const interceptor: HttpInterceptorFn = (req, next) => 
+    TestBed.runInInjectionContext(() => authInterceptor(req, next));
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+  });
+
+  it('should be created', () => {
+    expect(interceptor).toBeTruthy();
+  });
+});

--- a/src/app/auth/auth.interceptor.ts
+++ b/src/app/auth/auth.interceptor.ts
@@ -1,0 +1,13 @@
+import { HttpInterceptorFn } from '@angular/common/http';
+
+export const authInterceptor: HttpInterceptorFn = (req, next) => {
+  let token = localStorage.getItem('computer_comparator_jwt');
+  if (token) {
+    req = req.clone({
+      setHeaders: {
+        Authorization: `Bearer ${token}`
+      }
+    })
+  }
+  return next(req);
+};

--- a/src/app/auth/auth.service.spec.ts
+++ b/src/app/auth/auth.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { AuthService } from './auth.service';
+
+describe('AuthService', () => {
+  let service: AuthService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(AuthService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/auth/auth.service.ts
+++ b/src/app/auth/auth.service.ts
@@ -1,0 +1,33 @@
+import { Injectable } from '@angular/core';
+import { LoginRequest } from './login-request';
+import { BehaviorSubject, Observable, tap } from 'rxjs';
+import { LoginResponse } from './login-response';
+import { environment } from '../../environments/environment.development';
+import { HttpClient } from '@angular/common/http';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class AuthService {
+  private _authStatus = new BehaviorSubject<boolean>(false);
+  authStatus = this._authStatus.asObservable();
+
+  constructor(private http: HttpClient) { }
+
+  private setAuthStatus(value: boolean): void {
+    this._authStatus.next(value);
+  }
+
+  login(loginRequest: LoginRequest): Observable<LoginResponse> {
+    let url = `${environment.baseUrl}api/Admin/Login`;
+    return this.http.post<LoginResponse>(url, loginRequest)
+      .pipe(tap(loginResult => {
+        if (loginResult.success) {
+          localStorage.setItem('computer_comparator_jwt', loginResult.token);
+          this.setAuthStatus(true);
+        }
+      }));
+  }
+
+  logout(): void { }
+}

--- a/src/app/auth/auth.service.ts
+++ b/src/app/auth/auth.service.ts
@@ -29,5 +29,8 @@ export class AuthService {
       }));
   }
 
-  logout(): void { }
+  logout(): void {
+    localStorage.removeItem('computer_comparator_jwt');
+    this.setAuthStatus(false);
+  }
 }

--- a/src/app/auth/login-request.ts
+++ b/src/app/auth/login-request.ts
@@ -1,0 +1,4 @@
+export interface LoginRequest {
+    userName: string,
+    password: string
+}

--- a/src/app/auth/login-response.ts
+++ b/src/app/auth/login-response.ts
@@ -1,0 +1,5 @@
+export interface LoginResponse {
+    success: boolean,
+    message: string,
+    token: string
+}

--- a/src/app/auth/login.component.html
+++ b/src/app/auth/login.component.html
@@ -1,0 +1,20 @@
+<div class="login">
+    <h1>Login</h1>
+    <form [formGroup]="form" (ngSubmit)="onSubmit()">
+  
+        <mat-form-field>
+            <mat-label>Name:</mat-label>
+            <input matInput formControlName="userName" required="required" placeholder="Enter user name">
+        </mat-form-field>
+  
+        <mat-form-field>
+            <mat-label>Password:</mat-label>
+            <input matInput type="password" formControlName="password" required="required" placeholder="Enter password">
+        </mat-form-field>
+  
+        <div>
+            <button mat-flat-button color="primary" type="submit">Login</button>
+            <button mat-flat-button color="secondary" [routerLink]="['/']">Cancel</button>
+        </div>
+    </form>
+</div>

--- a/src/app/auth/login.component.spec.ts
+++ b/src/app/auth/login.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { LoginComponent } from './login.component';
+
+describe('LoginComponent', () => {
+  let component: LoginComponent;
+  let fixture: ComponentFixture<LoginComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [LoginComponent]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(LoginComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/auth/login.component.ts
+++ b/src/app/auth/login.component.ts
@@ -1,0 +1,46 @@
+import { Component } from '@angular/core';
+import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { Router, RouterLink } from '@angular/router';
+import { LoginRequest } from './login-request';
+import { AuthService } from './auth.service';
+
+@Component({
+  selector: 'app-login',
+  imports: [
+    ReactiveFormsModule,
+    MatFormFieldModule,
+    MatInputModule,
+    RouterLink
+  ],
+  templateUrl: './login.component.html',
+  styleUrl: './login.component.scss'
+})
+export class LoginComponent {
+  form!: FormGroup;
+
+  constructor(private authService: AuthService, private router: Router) { }
+
+  ngOnInit(): void {
+    this.form = new FormGroup({
+      userName: new FormControl('', Validators.required),
+      password: new FormControl('', Validators.required)
+    });
+  }
+
+  onSubmit() {
+    let loginRequest = <LoginRequest>{
+      userName: this.form.controls['userName'].value,
+      password: this.form.controls['password'].value
+    }
+    this.authService.login(loginRequest).subscribe({
+      next: result => {
+        if (result.success) {
+          this.router.navigate(['/']);
+        }
+      },
+      error: error => console.error(error)
+    })
+  }
+}

--- a/src/app/nav-bar/nav-bar.component.html
+++ b/src/app/nav-bar/nav-bar.component.html
@@ -7,6 +7,11 @@
         <a mat-flat-button color="primary" [routerLink]="['/offers', 'Desktops']">Desktops</a>
         <a mat-flat-button color="primary" [routerLink]="['/offers', 'Laptops']">Laptops</a>
         <span class="separator"></span>
-        <a mat-flat-button color="primary" [routerLink]="['/login']">Login</a>
+        @if (isLoggedIn) {
+          <a mat-flat-button color="primary" [routerLink]="['/login']" (click)="onLogout()">Logout</a>
+        }
+        @else {
+          <a mat-flat-button color="primary" [routerLink]="['/login']">Login</a>
+        }
     </mat-toolbar>
   </header>

--- a/src/app/nav-bar/nav-bar.component.html
+++ b/src/app/nav-bar/nav-bar.component.html
@@ -7,5 +7,6 @@
         <a mat-flat-button color="primary" [routerLink]="['/offers', 'Desktops']">Desktops</a>
         <a mat-flat-button color="primary" [routerLink]="['/offers', 'Laptops']">Laptops</a>
         <span class="separator"></span>
+        <a mat-flat-button color="primary" [routerLink]="['/login']">Login</a>
     </mat-toolbar>
   </header>

--- a/src/app/nav-bar/nav-bar.component.ts
+++ b/src/app/nav-bar/nav-bar.component.ts
@@ -1,7 +1,9 @@
-import { Component } from '@angular/core';
-import { RouterLink } from '@angular/router';
+import { Component, OnDestroy } from '@angular/core';
+import { Router, RouterLink } from '@angular/router';
 import { MatToolbarModule } from '@angular/material/toolbar';
 import { MatIconModule } from '@angular/material/icon';
+import { AuthService } from '../auth/auth.service';
+import { Subject, takeUntil } from 'rxjs';
  
  @Component({
    selector: 'app-nav-bar',
@@ -13,6 +15,23 @@ import { MatIconModule } from '@angular/material/icon';
    templateUrl: './nav-bar.component.html',
    styleUrl: './nav-bar.component.scss'
  })
- export class NavBarComponent {
- 
+ export class NavBarComponent implements OnDestroy {
+  private destroySubject = new Subject();
+  isLoggedIn: boolean = false;
+
+  constructor(private authService: AuthService, private router: Router) {
+    authService.authStatus.pipe(takeUntil(this.destroySubject)).subscribe(
+      result => this.isLoggedIn = result
+    )
+  }
+
+  onLogout(): void {
+    this.authService.logout();
+    this.router.navigate(['/']);
+  }
+
+  ngOnDestroy() {
+    this.destroySubject.next(true);
+    this.destroySubject.complete();
+  }
  }


### PR DESCRIPTION
To handle the JWT-based authentication required by the back-end API:

- Add a login component with a form and `AuthService` to send login requests with the form values.
- Swap between login and logout buttons depending on the state of an auth observable from `AuthService`.
  - Through this, the user receives indication of their authentication status.
  - Similarly, navigate to the homepage as an indication of success in either action.
- Use an interceptor to tack on the JWT, following the bearer scheme.